### PR TITLE
Fix desktop reveal animations: stagger above-fold elements and increa…

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,22 +18,57 @@ document.addEventListener('DOMContentLoaded', function() {
         const footerEl = document.querySelector('footer');
 
         if (revealElements.length > 0 || footerEl) {
-            const revealObserver = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('visible');
-                        revealObserver.unobserve(entry.target);
+            // Check if element is in the viewport
+            function isInViewport(el) {
+                const rect = el.getBoundingClientRect();
+                return rect.top < window.innerHeight - 50 && rect.bottom > 0;
+            }
+
+            // On load: stagger elements already visible in viewport
+            // so they cascade in instead of all appearing at once
+            setTimeout(() => {
+                const inView = [];
+                const belowFold = [];
+
+                revealElements.forEach(el => {
+                    if (isInViewport(el)) {
+                        inView.push(el);
+                    } else {
+                        belowFold.push(el);
                     }
                 });
-            }, {
-                threshold: 0.15,
-                rootMargin: '0px 0px -50px 0px'
-            });
 
-            // Delay to avoid fighting page transition overlay
-            setTimeout(() => {
-                revealElements.forEach(el => revealObserver.observe(el));
-                if (footerEl) revealObserver.observe(footerEl);
+                // Stagger above-fold elements with 120ms intervals
+                inView.forEach((el, i) => {
+                    setTimeout(() => {
+                        el.classList.add('visible');
+                    }, i * 120);
+                });
+
+                // Footer if in view
+                if (footerEl && isInViewport(footerEl)) {
+                    setTimeout(() => {
+                        footerEl.classList.add('visible');
+                    }, inView.length * 120);
+                }
+
+                // Set up observer for remaining below-fold elements
+                const revealObserver = new IntersectionObserver((entries) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            entry.target.classList.add('visible');
+                            revealObserver.unobserve(entry.target);
+                        }
+                    });
+                }, {
+                    threshold: 0.15,
+                    rootMargin: '0px 0px -50px 0px'
+                });
+
+                belowFold.forEach(el => revealObserver.observe(el));
+                if (footerEl && !isInViewport(footerEl)) {
+                    revealObserver.observe(footerEl);
+                }
             }, 300);
         }
     })();

--- a/style.css
+++ b/style.css
@@ -1055,8 +1055,8 @@ footer {
 /* --- Scroll Reveal System --- */
 .reveal {
     opacity: 0;
-    transform: translateY(30px);
-    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+    transform: translateY(40px);
+    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .reveal.visible {
     opacity: 1;
@@ -1065,8 +1065,8 @@ footer {
 
 .reveal-heading {
     opacity: 0;
-    transform: translateX(-20px);
-    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+    transform: translateX(-30px);
+    transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .reveal-heading.visible {
     opacity: 1;
@@ -1075,12 +1075,12 @@ footer {
 
 .reveal-image {
     opacity: 0;
-    transform: scale(0.97);
-    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+    transform: scale(0.95) translateY(20px);
+    transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .reveal-image.visible {
     opacity: 1;
-    transform: scale(1);
+    transform: scale(1) translateY(0);
 }
 
 /* Stagger delays */


### PR DESCRIPTION
…se animation intensity

- Elements already visible in viewport now cascade in with 120ms stagger intervals instead of all appearing at once (fixes animations being invisible on desktop)
- Increased translateY from 30px to 40px and translateX from 20px to 30px for more noticeable motion
- Added translateY(20px) to image reveals alongside scale for more visible entrance
- Switched easing from ease-out to cubic-bezier(0.16, 1, 0.3, 1) for snappier, more satisfying motion
- Below-fold elements still use IntersectionObserver for scroll-triggered reveals

https://claude.ai/code/session_01DUGRwwWoQWsuRjQLyW1X8S