### PR TITLE
Fix skills ticker layout on mobile — transform conflict with reveal c…

### DIFF
--- a/style.css
+++ b/style.css
@@ -461,7 +461,7 @@ h1, h2, h3, h4 {
     width: 100vw;
     position: relative;
     left: 50%;
-    transform: translateX(-50%);
+    margin-left: -50vw;
     overflow: hidden;
     padding: 1rem 0;
     border-top: 1px solid rgba(255, 255, 255, 0.2);
@@ -1090,6 +1090,15 @@ footer {
 .reveal-delay-4 { transition-delay: 0.4s; }
 .reveal-delay-5 { transition-delay: 0.5s; }
 .reveal-delay-6 { transition-delay: 0.6s; }
+
+/* Skills ticker reveal override - no transform to avoid conflicts */
+.skills-ticker.reveal {
+    transform: none;
+    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.skills-ticker.reveal.visible {
+    transform: none;
+}
 
 /* Footer reveal */
 footer .footer-links,


### PR DESCRIPTION
…lass

The .skills-ticker used transform: translateX(-50%) for full-width centering, which was overridden by the .reveal class transform: translateY(40px). Switched to margin-left: -50vw for centering and added a ticker-specific reveal override that uses opacity-only animation.

https://claude.ai/code/session_01DUGRwwWoQWsuRjQLyW1X8S