### PR TITLE
Fix skills ticker on mobile — remove reveal class, restore original c…

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                     <a href="about.html" class="btn-case-study">LEARN MORE ABOUT ME</a>
                 </div>
             </div>
-             <div class="skills-ticker reveal">
+             <div class="skills-ticker">
                 <div class="skills-track">
                     <span>ADOBE ILLUSTRATOR</span> <span>FIGMA</span> <span>3D PRINTING</span> <span>SOCIAL MEDIA MARKETING</span> <span>VACUUM FORMING</span> <span>LAYOUT DESIGN</span> <span>TROTEC LASER CUTTER</span> <span>CORPORATE BRANDING</span> <span>AFTER EFFECTS</span>
                     <span>ADOBE PHOTOSHOP</span> <span>INDESIGN</span> <span>CANVA</span> <span>UI/UX DESIGN</span> <span>PRINT PRODUCTION</span> <span>VIDEO EDITING</span> <span>BRAND IDENTITY</span> <span>TYPOGRAPHY</span> <span>PROBLEM-SOLVING</span>

--- a/style.css
+++ b/style.css
@@ -461,7 +461,7 @@ h1, h2, h3, h4 {
     width: 100vw;
     position: relative;
     left: 50%;
-    margin-left: -50vw;
+    transform: translateX(-50%);
     overflow: hidden;
     padding: 1rem 0;
     border-top: 1px solid rgba(255, 255, 255, 0.2);
@@ -1090,15 +1090,6 @@ footer {
 .reveal-delay-4 { transition-delay: 0.4s; }
 .reveal-delay-5 { transition-delay: 0.5s; }
 .reveal-delay-6 { transition-delay: 0.6s; }
-
-/* Skills ticker reveal override - no transform to avoid conflicts */
-.skills-ticker.reveal {
-    transform: none;
-    transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.skills-ticker.reveal.visible {
-    transform: none;
-}
 
 /* Footer reveal */
 footer .footer-links,


### PR DESCRIPTION
…entering

The skills ticker already has its own infinite scroll animation and doesn't need a reveal. The reveal class was conflicting with the transform: translateX(-50%) centering, causing the ticker to break on mobile. Removed reveal from the ticker and restored the original transform-based centering.

https://claude.ai/code/session_01DUGRwwWoQWsuRjQLyW1X8S