### PR TITLE
Add responsive typography and layout scaling for large screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -1428,3 +1428,132 @@ footer.visible p {
         transform: scale(2.75);
     }
 }
+
+/* ==================================================
+   Large Screen Optimizations (1440p, 1920p, 2K, 4K)
+   Scales typography via root font-size (rem cascade)
+   and widens content containers — especially work
+   pages that show galleries, video, or carousels.
+   ================================================== */
+
+/* Standard large desktops (≥1440px wide) */
+@media (min-width: 1440px) {
+    html {
+        font-size: 17px;
+    }
+    .page-section {
+        max-width: 1100px;
+    }
+    .page-section:has(.image-gallery-grid),
+    .page-section:has(.carousel-container),
+    .page-section:has(.video-embed-container),
+    .page-section:has(.single-image-container),
+    .page-section:has(.video-container) {
+        max-width: 70vw;
+    }
+    .modal-content {
+        max-width: 1400px;
+    }
+    .video-embed-container {
+        max-width: 1100px;
+    }
+    .work-grid {
+        max-width: 1000px;
+    }
+}
+
+/* QHD / 1080p+ (≥1920px wide) */
+@media (min-width: 1920px) {
+    html {
+        font-size: 18px;
+    }
+    .page-section {
+        max-width: 1300px;
+    }
+    .page-section:has(.image-gallery-grid),
+    .page-section:has(.carousel-container),
+    .page-section:has(.video-embed-container),
+    .page-section:has(.single-image-container),
+    .page-section:has(.video-container) {
+        max-width: 75vw;
+    }
+    .about-photo img {
+        max-width: 450px;
+    }
+    .modal-content {
+        max-width: 1600px;
+    }
+    .video-embed-container {
+        max-width: 1300px;
+    }
+    .page-section h1,
+    .page-section h2 {
+        font-size: 2.4rem;
+    }
+    .hero h1 {
+        font-size: 5vw;
+    }
+    .hero .subtitle {
+        font-size: 1.4rem;
+    }
+    .work-grid {
+        max-width: 1200px;
+    }
+    .carousel-item {
+        max-width: 600px;
+    }
+}
+
+/* 2K / 1440p screens (≥2560px wide) */
+@media (min-width: 2560px) {
+    html {
+        font-size: 20px;
+    }
+    .page-section {
+        max-width: 1500px;
+    }
+    .page-section:has(.image-gallery-grid),
+    .page-section:has(.carousel-container),
+    .page-section:has(.video-embed-container),
+    .page-section:has(.single-image-container),
+    .page-section:has(.video-container) {
+        max-width: 78vw;
+    }
+    .about-photo img {
+        max-width: 520px;
+    }
+    .modal-content {
+        max-width: 80vw;
+    }
+    .video-embed-container {
+        max-width: 1500px;
+    }
+    .page-section h1,
+    .page-section h2 {
+        font-size: 2.8rem;
+    }
+    .work-grid {
+        max-width: 1500px;
+        gap: 3rem;
+    }
+    .carousel-item {
+        max-width: 720px;
+    }
+}
+
+/* 4K / UHD (≥3440px wide) */
+@media (min-width: 3440px) {
+    html {
+        font-size: 22px;
+    }
+    .page-section:has(.image-gallery-grid),
+    .page-section:has(.carousel-container),
+    .page-section:has(.video-embed-container),
+    .page-section:has(.single-image-container),
+    .page-section:has(.video-container) {
+        max-width: 80vw;
+    }
+    .modal-content {
+        max-width: 82vw;
+    }
+}


### PR DESCRIPTION
## Summary
Added comprehensive media query breakpoints to optimize the site's typography and layout for large displays (1440px and above), including 1440p, 1920p, 2K, and 4K resolutions.

## Key Changes
- **1440px+ breakpoint**: Increased root font-size to 17px and widened `.page-section` to 1100px; gallery/video/carousel containers expand to 70vw
- **1920px+ breakpoint**: Increased root font-size to 18px, widened `.page-section` to 1300px, and expanded media containers to 75vw; added explicit heading and hero sizing
- **2560px+ breakpoint (2K)**: Increased root font-size to 20px, widened `.page-section` to 1500px, expanded media containers to 78vw, and increased work grid gap to 3rem
- **3440px+ breakpoint (4K)**: Increased root font-size to 22px and expanded media containers to 80vw

## Implementation Details
- Uses CSS `rem` cascade for typography scaling via root `font-size` adjustments, ensuring all relative units scale proportionally
- Employs `:has()` selector to target `.page-section` containers with media content (galleries, carousels, videos) for wider layouts
- Progressively increases container widths and viewport-relative sizing (vw units) as screen size increases
- Maintains consistent spacing and proportions across all breakpoints while maximizing content utilization on ultra-wide displays

https://claude.ai/code/session_011eGj1XWF1BYEVxT6fLHK11