### PR TITLE
Add two new project showcases to advertisement portfolio

### DIFF
--- a/advertisement.html
+++ b/advertisement.html
@@ -454,6 +454,43 @@
      END OF PASTE BLOCK
      ============================================================ -->
 
+            <div class="project-detail-showcase">
+                <h3 class="reveal-heading">OWNED — Steam: Own Everything. Owe Nothing.</h3>
+                <p class="project-description reveal">
+                    An integrated thesis campaign for Steam that turns its permanent ownership model into a cultural stance against subscription fatigue. OWNED takes former platform exclusives — characters once locked to PlayStation and Xbox — and shows them permanently held in Steam's collection. They aren't going anywhere. They belong to you now.
+                </p>
+                <div class="image-gallery-grid" data-stagger="image">
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-1.png" alt="OWNED Steam campaign — title slide: Own Everything. Owe Nothing." loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-2.png" alt="OWNED Steam campaign — project background: brief and target market summary" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-3.png" alt="OWNED Steam campaign — research: competitive audit, market signal, and cultural context" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-4.png" alt="OWNED Steam campaign — insight on the emotional value of ownership" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-5.png" alt="OWNED Steam campaign — campaign idea and tagline: Own Everything. Owe Nothing." loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-14.png" alt="OWNED Steam campaign — print magazine spread mockup featuring an exclusive character" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/OWNED_Thesis_Deck-18.png" alt="OWNED Steam campaign — Instagram triptych: They Cannot Leave" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/OWNED_Thesis_Deck-19.png" alt="OWNED Steam campaign — branded ownership case-file labels" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/OWNED_Thesis_Deck-20.png" alt="OWNED Steam campaign — tonal black-on-black OWNED merch t-shirt" loading="lazy" decoding="async"></div>
+                </div>
+            </div>
+
+            <div class="project-detail-showcase">
+                <h3 class="reveal-heading">Philips Smart Sleep: Wake Like A Human</h3>
+                <p class="project-description reveal">
+                    An out-of-home campaign for the Philips Sunrise Alarm Clock. Built on a biological truth: your brain doesn't know what an alarm is — it still takes its cues from the sun. The campaign reframes the alarm clock as a 30-year-old intruder on a 300,000-year-old body, and positions Philips as the natural, human alternative.
+                </p>
+                <div class="image-gallery-grid" data-stagger="image">
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-1.png" alt="Philips Smart Sleep — title slide: Wake Like A Human, Out-of-Home campaign for the Sunrise Alarm Clock" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-2.png" alt="Philips Smart Sleep — business problem: most people start their day in a state of stress" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-3.png" alt="Philips Smart Sleep — insight: your brain still takes its cues from the sun" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-4.png" alt="Philips Smart Sleep — the idea: your body is 300,000 years old, your alarm clock is 30" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-11.png" alt="Philips Smart Sleep — radio script: The Alarm Clock Apology" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item span-2"><img src="./images/Philips_OOH_Campaign-12.png" alt="Philips Smart Sleep — radio script: The Alarm Clock's Obituary" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/Philips_OOH_Campaign-6.png" alt="Philips Smart Sleep — billboard mockup: Sunrise built you. A buzzer broke you." loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/Philips_OOH_Campaign-8.png" alt="Philips Smart Sleep — wild posting: You've been waking wrong your whole life." loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/Philips_OOH_Campaign-9.png" alt="Philips Smart Sleep — bedside product shot of the Philips Sunrise Alarm Clock" loading="lazy" decoding="async"></div>
+                    <div class="gallery-grid-item"><img src="./images/Philips_OOH_Campaign-10.png" alt="Philips Smart Sleep — direct mail postcard with QR code" loading="lazy" decoding="async"></div>
+                </div>
+            </div>
+
             <div class="related-work reveal">
                 <h3>Related Work</h3>
                 <div class="related-grid">


### PR DESCRIPTION
## Summary
Added two new project detail showcases to the advertisement portfolio page: the OWNED Steam campaign and the Philips Smart Sleep out-of-home campaign.

## Changes Made
- **OWNED Steam Campaign**: Added a complete project showcase featuring a thesis campaign that positions Steam's permanent ownership model against subscription fatigue. Includes 9 gallery items showcasing the campaign deck, print mockups, social media concepts, and merchandise.

- **Philips Smart Sleep Campaign**: Added an out-of-home campaign showcase for the Philips Sunrise Alarm Clock. Includes 10 gallery items demonstrating the campaign concept, business problem, insights, creative executions (billboards, wild posting, direct mail), and product photography.

## Implementation Details
- Both sections follow the existing `project-detail-showcase` structure with consistent markup patterns
- Gallery items use the `image-gallery-grid` component with appropriate `span-2` classes for layout control
- All images include descriptive alt text and lazy loading attributes (`loading="lazy" decoding="async"`)
- Sections include reveal animations via `reveal-heading` and `reveal` classes
- Positioned before the "Related Work" section to maintain page hierarchy

https://claude.ai/code/session_01SkLXUFZ8KS74VdVENArNjn