### PR TITLE
Add Ctrl-hover image preview popup feature

### DIFF
--- a/script.js
+++ b/script.js
@@ -1075,4 +1075,90 @@ document.addEventListener('DOMContentLoaded', function() {
         resizeCanvas();
         startGame();
     }
+
+    // --- Ctrl-hover Image Preview ---
+    (function initImagePreview() {
+        if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) return;
+
+        let popup = null;
+        let popupImg = null;
+        let currentTarget = null;
+        let modifierDown = false;
+
+        function isPreviewable(el) {
+            if (!el || el.tagName !== 'IMG') return false;
+            if (el.classList.contains('logo-img')) return false;
+            if (el.hasAttribute('data-no-preview')) return false;
+            if (el.closest('[data-no-preview]')) return false;
+            return true;
+        }
+
+        function ensurePopup() {
+            if (popup) return;
+            popup = document.createElement('div');
+            popup.className = 'image-preview-popup';
+            popup.setAttribute('aria-hidden', 'true');
+            popupImg = document.createElement('img');
+            popupImg.alt = '';
+            popup.appendChild(popupImg);
+            document.body.appendChild(popup);
+        }
+
+        function showPopup(img) {
+            ensurePopup();
+            const src = img.currentSrc || img.src;
+            if (popupImg.getAttribute('src') !== src) popupImg.src = src;
+            popupImg.alt = img.alt || '';
+            popup.classList.add('is-visible');
+            currentTarget = img;
+        }
+
+        function hidePopup() {
+            if (!popup) return;
+            popup.classList.remove('is-visible');
+            currentTarget = null;
+        }
+
+        document.addEventListener('mouseover', (e) => {
+            if (!modifierDown) return;
+            const img = e.target.closest && e.target.closest('img');
+            if (img && isPreviewable(img) && img !== currentTarget) {
+                showPopup(img);
+            }
+        });
+
+        document.addEventListener('mouseout', (e) => {
+            if (!currentTarget) return;
+            const fromImg = e.target.closest && e.target.closest('img');
+            if (fromImg !== currentTarget) return;
+            const toEl = e.relatedTarget;
+            const toImg = toEl && toEl.closest ? toEl.closest('img') : null;
+            if (toImg && isPreviewable(toImg)) return;
+            hidePopup();
+        });
+
+        window.addEventListener('keydown', (e) => {
+            if (e.key !== 'Control' && e.key !== 'Meta') return;
+            if (modifierDown) return;
+            modifierDown = true;
+            const hovered = document.querySelector('img:hover');
+            if (hovered && isPreviewable(hovered)) showPopup(hovered);
+        });
+
+        window.addEventListener('keyup', (e) => {
+            if (e.key !== 'Control' && e.key !== 'Meta') return;
+            modifierDown = false;
+            hidePopup();
+        });
+
+        window.addEventListener('blur', () => {
+            modifierDown = false;
+            hidePopup();
+        });
+
+        window.addEventListener('contextmenu', () => {
+            modifierDown = false;
+            hidePopup();
+        });
+    })();
 });

--- a/style.css
+++ b/style.css
@@ -1735,3 +1735,35 @@ footer.visible p {
         max-width: 82vw;
     }
 }
+
+/* --- Ctrl-hover Image Preview --- */
+.image-preview-popup {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4vh 4vw;
+    background: rgba(0, 0, 0, 0.88);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    z-index: 100000;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+}
+.image-preview-popup.is-visible {
+    opacity: 1;
+    visibility: visible;
+}
+.image-preview-popup img {
+    max-width: 92vw;
+    max-height: 92vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+    background: #111;
+    border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
This PR adds an interactive image preview feature that displays a fullscreen popup when users hover over images while holding the Ctrl (or Cmd on Mac) key.

## Key Changes
- **JavaScript (script.js)**: Added `initImagePreview()` IIFE that:
  - Detects Ctrl/Cmd key presses and releases
  - Shows a fullscreen preview popup when hovering over previewable images with modifier key held
  - Hides the popup when the modifier key is released or user moves away from the image
  - Includes safety checks to exclude logo images and elements marked with `data-no-preview` attribute
  - Handles edge cases like window blur and context menu events

- **CSS (style.css)**: Added styling for the preview popup:
  - Fullscreen overlay with semi-transparent dark background and blur effect
  - Smooth fade in/out transitions (150ms)
  - Responsive image sizing with proper aspect ratio preservation
  - High z-index (100000) to ensure it appears above all other content
  - Subtle shadow and rounded corners for visual polish

## Implementation Details
- Feature only activates on devices with hover capability and fine pointer control (excludes touch devices)
- Uses `currentSrc` property to support responsive images with `srcset`
- Implements proper accessibility with `aria-hidden` attribute on popup
- Prevents pointer events on the popup itself to avoid interfering with page interaction
- Gracefully handles modifier key state across multiple event types (keydown, keyup, blur, contextmenu)

https://claude.ai/code/session_01FvXrB5Xe1BYhC9H9ynReyt