### PR TITLE
Update UI design portfolio with new projects and meta descriptions

### DIFF
--- a/ui-design.html
+++ b/ui-design.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>UI/Web Design Portfolio - Divshaan Singh Brar | User Interface & Web Experiences</title>
-    <meta name="description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, a website redesign concept for Berkshire Hathaway, and the Khushman Dhillon Law website.">
+    <meta name="description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, Berkshire Hathaway redesign, Khushman Dhillon Law website, Portfolio site, and FSTV.">
     <link rel="canonical" href="https://divshaan.design/ui-design.html">
 
     <!-- Open Graph -->
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="Divshaan Singh Brar — Portfolio">
     <meta property="og:title" content="UI/Web Design Portfolio - Divshaan Singh Brar | User Interface & Web Experiences">
-    <meta property="og:description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, a website redesign concept for Berkshire Hathaway, and the Khushman Dhillon Law website.">
+    <meta property="og:description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, Berkshire Hathaway redesign, Khushman Dhillon Law website, Portfolio site, and FSTV.">
     <meta property="og:url" content="https://divshaan.design/ui-design.html">
     <meta property="og:image" content="https://divshaan.design/assets/og-image.jpg">
     <meta property="og:image:width" content="1200">
@@ -21,7 +21,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="UI/Web Design Portfolio - Divshaan Singh Brar | User Interface & Web Experiences">
-    <meta name="twitter:description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, a website redesign concept for Berkshire Hathaway, and the Khushman Dhillon Law website.">
+    <meta name="twitter:description" content="Explore Divshaan Singh Brar's UI/Web design portfolio, including the Gamescom website design, Berkshire Hathaway redesign, Khushman Dhillon Law website, Portfolio site, and FSTV.">
     <meta name="twitter:image" content="https://divshaan.design/assets/og-image.jpg">
 
     <link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
@@ -116,6 +116,42 @@
                 <!-- Button to open in full screen -->
                 <div style="margin-top: 1.5rem; text-align: center;">
                     <a href="https://khushman.ca/" target="_blank" class="btn-case-study">OPEN IN NEW TAB</a>
+                </div>
+            </div>
+
+            <!-- NEW SECTION: Portfolio Website -->
+            <div class="project-detail-showcase">
+                <h3 class="reveal-heading">Portfolio Website</h3>
+                <p class="project-description reveal">
+                    A personal portfolio website built to showcase creative work across design disciplines. You can browse the live site below.
+                </p>
+
+                <!-- Live Website Embed -->
+                <div class="video-embed-container reveal" style="height: 600px; padding-bottom: 0;">
+                    <iframe src="https://divshaan.design/portfolio/" style="width: 100%; height: 100%; border: none;" title="Portfolio Website Preview"></iframe>
+                </div>
+
+                <!-- Button to open in full screen -->
+                <div style="margin-top: 1.5rem; text-align: center;">
+                    <a href="https://divshaan.design/portfolio/" target="_blank" class="btn-case-study">OPEN IN NEW TAB</a>
+                </div>
+            </div>
+
+            <!-- NEW SECTION: FSTV -->
+            <div class="project-detail-showcase">
+                <h3 class="reveal-heading">FSTV</h3>
+                <p class="project-description reveal">
+                    A web design project for FSTV. You can browse the live site below.
+                </p>
+
+                <!-- Live Website Embed -->
+                <div class="video-embed-container reveal" style="height: 600px; padding-bottom: 0;">
+                    <iframe src="https://divshaan.design/FSTV/" style="width: 100%; height: 100%; border: none;" title="FSTV Website Preview"></iframe>
+                </div>
+
+                <!-- Button to open in full screen -->
+                <div style="margin-top: 1.5rem; text-align: center;">
+                    <a href="https://divshaan.design/FSTV/" target="_blank" class="btn-case-study">OPEN IN NEW TAB</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
Updated the UI/Web Design portfolio page to include two new project showcases (Portfolio Website and FSTV) and refreshed meta descriptions across SEO and social media tags to reflect the expanded portfolio.

## Key Changes
- **Meta Description Updates**: Updated `meta description`, `og:description`, and `twitter:description` tags to mention all portfolio projects including the newly added Portfolio site and FSTV
- **New Project Sections**: Added two new project showcase sections:
  - Portfolio Website: Personal portfolio site with embedded iframe preview and link to open in new tab
  - FSTV: Web design project with embedded iframe preview and link to open in new tab
- **Consistent Styling**: Both new sections follow the existing `project-detail-showcase` pattern with reveal animations, descriptions, embedded iframes (600px height), and "OPEN IN NEW TAB" call-to-action buttons

## Implementation Details
- Embedded iframes use `https://divshaan.design/portfolio/` and `https://divshaan.design/FSTV/` as sources
- Both sections include proper accessibility attributes (`title` on iframes)
- Maintains consistent spacing with `margin-top: 1.5rem` for the action buttons
- Uses existing CSS classes (`reveal-heading`, `project-description`, `reveal`, `btn-case-study`) for visual consistency
- New sections are positioned before the "Related Work" section

https://claude.ai/code/session_01VKLhTu8GnVGkiHP831iUby