### PR TITLE
Smoother work thumbnails, cursor circle default, Duo hero swap

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,9 +6,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const cursor = document.createElement('div');
         cursor.className = 'custom-cursor';
-        const inner = document.createElement('div');
-        inner.className = 'custom-cursor-inner';
-        cursor.appendChild(inner);
+        const dot = document.createElement('div');
+        dot.className = 'custom-cursor-inner custom-cursor-dot';
+        const tri = document.createElement('div');
+        tri.className = 'custom-cursor-inner custom-cursor-tri';
+        cursor.appendChild(dot);
+        cursor.appendChild(tri);
         document.body.appendChild(cursor);
 
         const SIZE = 88;

--- a/style.css
+++ b/style.css
@@ -1587,23 +1587,47 @@ footer.visible p {
     }
 
     .custom-cursor-inner {
-        width: 100%;
-        height: 100%;
-        background-color: #FFFFFF;
-        /* Square — written as a 4-point polygon so it can interpolate with the
-           triangle polygon below without snapping. */
-        clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
-        transition: clip-path 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-        will-change: clip-path;
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
     }
 
-    .custom-cursor.cursor-hover .custom-cursor-inner {
-        /* Triangle — apex sits at the cursor position (50%, 0%). The first two
-           points share that apex so the path keeps the same point count as the
-           square, allowing a smooth morph. Base spans 15%–85% at 70% height,
-           giving an isoceles triangle ~62px tall: smaller than the 88px square,
-           larger than the original 32px circle. */
-        clip-path: polygon(50% 0%, 50% 0%, 85% 70%, 15% 70%);
+    /* Default — small white circle, ~22px, centered in the 88px hotspot box. */
+    .custom-cursor-dot {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 22px;
+        height: 22px;
+        margin: -11px 0 0 -11px;
+        background-color: #FFFFFF;
+        border-radius: 50%;
+        opacity: 1;
+        transition: opacity 0.18s ease, transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+        will-change: opacity, transform;
+    }
+
+    /* Click target — triangle whose apex sits at the cursor (50%, 0%). */
+    .custom-cursor-tri {
+        position: absolute;
+        inset: 0;
+        background-color: #FFFFFF;
+        clip-path: polygon(50% 0%, 85% 70%, 15% 70%);
+        opacity: 0;
+        transform: scale(0.7);
+        transform-origin: 50% 0%;
+        transition: opacity 0.18s ease, transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+        will-change: opacity, transform;
+    }
+
+    .custom-cursor.cursor-hover .custom-cursor-dot {
+        opacity: 0;
+        transform: scale(0.4);
+    }
+
+    .custom-cursor.cursor-hover .custom-cursor-tri {
+        opacity: 1;
+        transform: scale(1);
     }
 }
 
@@ -1920,16 +1944,23 @@ footer.visible p {
   filter: grayscale(80%); transition: filter 0.4s ease;
 }
 .work-project-card:hover img { filter: grayscale(0%); }
-.work-project-card iframe {
+.work-project-card-iframe {
   position: absolute;
   top: 0; left: 0;
-  width: 100%; height: 100%;
+  width: 200%; height: 200%;
+  transform: scale(0.5);
+  transform-origin: top left;
   border: 0;
   pointer-events: none;
   filter: grayscale(80%);
   transition: filter 0.4s ease;
 }
-.work-project-card:hover iframe { filter: grayscale(0%); }
+.work-project-card:hover .work-project-card-iframe { filter: grayscale(0%); }
+.work-project-card-iframe-shield {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
 .work-project-card-content {
   position: absolute;
   bottom: 0; left: 0; right: 0;

--- a/work.html
+++ b/work.html
@@ -139,7 +139,8 @@
                 </a>
 
                 <a href="work/berkshire-hathaway.html" class="work-project-card" data-category="web">
-                    <iframe src="https://divshaan.github.io/BERKSHIRE-HATHAWAY-Sample/" title="Berkshire Hathaway Website Preview" loading="lazy"></iframe>
+                    <iframe class="work-project-card-iframe" src="https://divshaan.github.io/BERKSHIRE-HATHAWAY-Sample/" title="Berkshire Hathaway Website Preview" loading="lazy" tabindex="-1" aria-hidden="true"></iframe>
+                    <span class="work-project-card-iframe-shield" aria-hidden="true"></span>
                     <div class="work-project-card-content">
                         <span class="work-project-card-cat">Web &amp; UI</span>
                         <h3 class="work-project-card-title">Berkshire Hathaway: Website Redesign</h3>
@@ -147,7 +148,8 @@
                 </a>
 
                 <a href="work/khushman-law.html" class="work-project-card" data-category="web">
-                    <iframe src="https://khushman.ca/" title="Khushman Dhillon Law Website Preview" loading="lazy"></iframe>
+                    <iframe class="work-project-card-iframe" src="https://khushman.ca/" title="Khushman Dhillon Law Website Preview" loading="lazy" tabindex="-1" aria-hidden="true"></iframe>
+                    <span class="work-project-card-iframe-shield" aria-hidden="true"></span>
                     <div class="work-project-card-content">
                         <span class="work-project-card-cat">Web &amp; UI</span>
                         <h3 class="work-project-card-title">Khushman Dhillon Law</h3>
@@ -155,7 +157,8 @@
                 </a>
 
                 <a href="work/portfolio-site.html" class="work-project-card" data-category="web">
-                    <iframe src="https://divshaan.design/portfolio/" title="Portfolio Website Preview" loading="lazy"></iframe>
+                    <iframe class="work-project-card-iframe" src="https://divshaan.design/portfolio/" title="Portfolio Website Preview" loading="lazy" tabindex="-1" aria-hidden="true"></iframe>
+                    <span class="work-project-card-iframe-shield" aria-hidden="true"></span>
                     <div class="work-project-card-content">
                         <span class="work-project-card-cat">Web &amp; UI</span>
                         <h3 class="work-project-card-title">Portfolio Website</h3>
@@ -163,7 +166,8 @@
                 </a>
 
                 <a href="work/fstv.html" class="work-project-card" data-category="web">
-                    <iframe src="https://divshaan.design/FSTV/" title="FSTV Website Preview" loading="lazy"></iframe>
+                    <iframe class="work-project-card-iframe" src="https://divshaan.design/FSTV/" title="FSTV Website Preview" loading="lazy" tabindex="-1" aria-hidden="true"></iframe>
+                    <span class="work-project-card-iframe-shield" aria-hidden="true"></span>
                     <div class="work-project-card-content">
                         <span class="work-project-card-cat">Web &amp; UI</span>
                         <h3 class="work-project-card-title">FSTV</h3>

--- a/work/duolingo.html
+++ b/work/duolingo.html
@@ -69,7 +69,7 @@
             </div>
 
             <div class="case-hero-image reveal-image">
-                <img src="../images/duo1.jpg" alt="Duolingo Valentine's campaign — 'Let Duo Play The Cupid This Valentines' opening visual" loading="eager" decoding="async">
+                <img src="../images/duo6.jpg" alt="Duolingo Valentine's campaign — out-of-home Cupid execution" loading="eager" decoding="async">
             </div>
 
             <div class="case-intro">


### PR DESCRIPTION
- Duolingo case study now uses duo6.jpg (OOH Cupid execution) as the hero — a more distinctive visual than the title slide.
- Work-page iframe thumbnails render at 2x size scaled to 50% so the embedded sites render at full desktop width and downsample cleanly; added a transparent shield span so hover/scroll never interacts with the iframe.
- Custom cursor: replaced the square→triangle clip-path morph with a small white circle (default) that crossfades into the triangle on clickables. Smoother on every page; matches what was requested.

https://claude.ai/code/session_01PR5TheShfCoDv6y6f2LnKr