### PR TITLE
Update copyright year from 2025 to 2026

### DIFF
--- a/404.html
+++ b/404.html
@@ -74,7 +74,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/about.html
+++ b/about.html
@@ -211,7 +211,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -84,7 +84,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/illustrations.html
+++ b/illustrations.html
@@ -115,7 +115,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/more-work.html
+++ b/more-work.html
@@ -123,7 +123,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>

--- a/photoshop.html
+++ b/photoshop.html
@@ -106,7 +106,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/print.html
+++ b/print.html
@@ -116,7 +116,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/sketches.html
+++ b/sketches.html
@@ -98,7 +98,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/social-media.html
+++ b/social-media.html
@@ -91,7 +91,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/video.html
+++ b/video.html
@@ -89,7 +89,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>© 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>© 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work.html
+++ b/work.html
@@ -177,7 +177,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>

--- a/work/berkshire-hathaway.html
+++ b/work/berkshire-hathaway.html
@@ -102,7 +102,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/depop.html
+++ b/work/depop.html
@@ -130,7 +130,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/duolingo.html
+++ b/work/duolingo.html
@@ -142,7 +142,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/fstv.html
+++ b/work/fstv.html
@@ -102,7 +102,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/gamescom-editorial.html
+++ b/work/gamescom-editorial.html
@@ -130,7 +130,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/gamescom-ui.html
+++ b/work/gamescom-ui.html
@@ -114,7 +114,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/khushman-law.html
+++ b/work/khushman-law.html
@@ -102,7 +102,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/owned-steam.html
+++ b/work/owned-steam.html
@@ -146,7 +146,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/philips-smart-sleep.html
+++ b/work/philips-smart-sleep.html
@@ -142,7 +142,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/portfolio-site.html
+++ b/work/portfolio-site.html
@@ -102,7 +102,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/red-cross-panic.html
+++ b/work/red-cross-panic.html
@@ -133,7 +133,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/sapporo-sabbatical.html
+++ b/work/sapporo-sabbatical.html
@@ -241,7 +241,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/tanya-talaga.html
+++ b/work/tanya-talaga.html
@@ -114,7 +114,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 

--- a/work/xbox-beyond-box.html
+++ b/work/xbox-beyond-box.html
@@ -106,7 +106,7 @@
             <a href="https://www.linkedin.com/in/divshaan-singh-brar-038b97251" target="_blank"><i class="bi bi-linkedin"></i> LINKEDIN</a>
             <a href="https://rgd.ca/members/profile/241008117" target="_blank"><i class="bi bi-person-badge"></i> RGD PROFILE</a>
         </div>
-        <p>&copy; 2025 Divshaan Singh Brar. All rights reserved.</p>
+        <p>&copy; 2026 Divshaan Singh Brar. All rights reserved.</p>
         <p class="footer-meta">Brampton, Ontario · Canada</p>
     </footer>
 


### PR DESCRIPTION
## Summary
Updated the copyright year in footer sections across all HTML pages from 2025 to 2026 to reflect the current year.

## Changes Made
- Updated copyright year in footer elements across 31 HTML files
- Changes include main pages (index, about, contact, work, etc.) and all work portfolio detail pages
- Consistent update of `&copy; 2025` to `&copy; 2026` in footer copyright notices

## Files Modified
- Root pages: 404.html, about.html, contact.html, illustrations.html, index.html, more-work.html, photoshop.html, print.html, sketches.html, social-media.html, video.html, work.html
- Work portfolio pages: 16 project detail pages in the work/ directory

This is a routine annual maintenance update to keep copyright notices current.

https://claude.ai/code/session_01U3cF9dtLpF7azncQ6DHmJ3